### PR TITLE
Epic refactoring, stage III: infrastructural simplification of unbounded recursion encoding

### DIFF
--- a/VSharp.CSharpUtils/Tests/ClassesSimple.cs
+++ b/VSharp.CSharpUtils/Tests/ClassesSimple.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.Remoting.Messaging;
-
-namespace VSharp.CSharpUtils.Tests
+﻿namespace VSharp.CSharpUtils.Tests
 {
     internal class ClassesSimpleA
     {

--- a/VSharp.SILI/DecompilerServices.fs
+++ b/VSharp.SILI/DecompilerServices.fs
@@ -85,14 +85,14 @@ module internal DecompilerServices =
     let private embodyGetter (property : IDecompiledProperty) =
         if property.Getter <> null && not property.IsAuto && property.Getter.Body = null then
             hackBuggyAutoProperty property embodyAutoGetter
-        else if property.Getter <> null && property.IsAuto && property.Getter.Body = null then
+        elif property.Getter <> null && property.IsAuto && property.Getter.Body = null then
             embodyAutoGetter property property.BackingField
         property.Getter
 
     let private embodySetter (property : IDecompiledProperty) =
         if property.Setter <> null && not property.IsAuto && property.Setter.Body = null then
             hackBuggyAutoProperty property embodyAutoSetter
-        else if property.Setter <> null && property.IsAuto && property.Setter.Body = null then
+        elif property.Setter <> null && property.IsAuto && property.Setter.Body = null then
             embodyAutoSetter property property.BackingField
         property.Setter
 

--- a/VSharp.SILI/Functions.fs
+++ b/VSharp.SILI/Functions.fs
@@ -9,18 +9,18 @@ type WriteDependence =
     | UnboundedAllocation of Term * Term
 
 module Functions =
-    type SymbolicLambda<'a> = State.state -> Term list -> (StatementResult * State.state -> 'a) -> 'a
+    type internal SymbolicLambda<'a> = State.state -> Term list State.SymbolicValue -> (StatementResult * State.state -> 'a) -> 'a
 
-    let public MakeLambda state (metadataMethod : IMetadataMethod) (lambda : SymbolicLambda<'a>) =
+    let internal MakeLambda state (metadataMethod : IMetadataMethod) (lambda : SymbolicLambda<'a>) =
         let typ = Types.FromMetadataMethodSignature metadataMethod in
         let term = Concrete(lambda, typ) in
         Memory.allocateInHeap state term
 
-    let public MakeLambdaTerm (signature : IFunctionSignature) (returnMetadataType : IMetadataType) (lambda : SymbolicLambda<'a>) =
+    let internal MakeLambdaTerm (signature : IFunctionSignature) (returnMetadataType : IMetadataType) (lambda : SymbolicLambda<'a>) =
         let typ = Types.FromDecompiledSignature signature returnMetadataType in
         Concrete(lambda, typ)
 
-    let public MakeLambda2 state (signature : IFunctionSignature) (returnMetadataType : IMetadataType) (lambda : SymbolicLambda<'a>) =
+    let internal MakeLambda2 state (signature : IFunctionSignature) (returnMetadataType : IMetadataType) (lambda : SymbolicLambda<'a>) =
         let term = MakeLambdaTerm signature returnMetadataType lambda in
         if Transformations.isInlinedSignatureCall signature
             then Memory.allocateInHeap state term
@@ -31,135 +31,164 @@ module Functions =
             Some(Lambda(lambda :?> SymbolicLambda<'a>))
         | _ -> None
 
-    module UnboundedRecursionCache =
-        type UnboundedApproximationState = NotStarted | InProgress | Ready
+    module UnboundedRecursionExplorer =
 
-        let private unboundedApproximationFinished = new Dictionary<FunctionIdentifier, bool>()
+        type SymbolicEffect = State.state -> State.state
+
         let private unboundedApproximationAttempts = new Dictionary<FunctionIdentifier, int>()
-        let private unboundedApproximationSymbolicState = new Dictionary<FunctionIdentifier, State.state>()
-        let private unboundedFunctionResult = new Dictionary<FunctionIdentifier, StatementResult>()
-        let private readDependencies = new Dictionary<FunctionIdentifier, (Term * Term) list>()
-        let private writeDependencies = new  Dictionary<FunctionIdentifier, Memory.StateDiff list>()
+        let private initialStates = new Dictionary<FunctionIdentifier, State.state>()
+        let private symbolicEffects = new Dictionary<FunctionIdentifier, SymbolicEffect list>()
+        let private symbolicResults = new Dictionary<FunctionIdentifier, StatementResult>()
+        let private terminationRelatedState = new Dictionary<FunctionIdentifier, Term seq>()
 
-        let public clear () =
-            unboundedApproximationAttempts.Clear()
-            unboundedApproximationSymbolicState.Clear()
-            unboundedFunctionResult.Clear()
-            readDependencies.Clear()
-            writeDependencies.Clear()
+        type IInterpreter =
+            abstract member InitializeStaticMembers : State.state -> string -> (StatementResult * State.state -> 'a) -> 'a
+            abstract member Invoke : FunctionIdentifier -> State.state -> Term option -> (StatementResult * State.state -> 'a) -> 'a
+        type private NullActivator() =
+            interface IInterpreter with
+                member this.InitializeStaticMembers _ _ _ =
+                    internalfail "interpreter for unbounded recursion is not ready"
+                member this.Invoke _ _ _ _ =
+                    internalfail "interpreter for unbounded recursion is not ready"
+        let mutable interpreter : IInterpreter = new NullActivator() :> IInterpreter
 
-        let private findReadDependencies terms =
-            let filterMapConstant deps = function
-                | Constant(_, LazyInstantiation location, _) as term when not (List.exists (fst >> ((=) location)) deps) ->
-                    Some (location, term)
-                | _ -> None
-            let unsorted = Terms.filterMapConstants filterMapConstant terms in
-            List.sortWith (fun (loc1, _) (loc2, _) -> Memory.compareRefs loc1 loc2) unsorted
+//        let private findReadDependencies terms =
+//            let filterMapConstant deps = function
+//                | Constant(_, LazyInstantiation location, _) as term when not (List.exists (fst >> ((=) location)) deps) ->
+//                    Some (location, term)
+//                | _ -> None
+//            let unsorted = Terms.filterMapConstants filterMapConstant terms in
+//            List.sortWith (fun (loc1, _) (loc2, _) -> Memory.compareRefs loc1 loc2) unsorted
+//
+//        let private overwriteReadWriteDependencies id readDeps writeDeps =
+//            let currentWriteDeps = writeDependencies.[id] in
+//            readDependencies.[id] <- readDeps
+//            writeDependencies.[id] <- writeDeps
+//            let result = List.length currentWriteDeps = List.length writeDeps
+//            unboundedApproximationFinished.[id] <- result
+//            result
+//
+//        let private exceptionsFirst (xG, xS) (yG, yS) =
+//            match xS, yS with
+//            | _ when xS = yS -> 0
+//            | Throw _, _ -> -1
+//            | _, _ -> 1
+//
+//        let private bubbleUpExceptions = function
+//            | Guarded gvs -> List.sortWith exceptionsFirst gvs |> Guarded
+//            | r -> r
+//
+//        let rec private makeMutuallyExclusiveGuards acc res xs =
+//            match xs with
+//            | [] -> Terms.MakeNAry OperationType.LogicalAnd (List.map (fun t -> Terms.Negate t) acc) false Bool |> fun g -> g::res
+//            | x::xs -> Terms.MakeNAry OperationType.LogicalAnd (x::(List.map (fun t -> Terms.Negate t) acc)) false Bool |> fun g -> makeMutuallyExclusiveGuards (x::acc) (g::res) xs
+//
+//        let private mutuallyExclusiveGuards guards =
+//            match guards with
+//            | [] -> internalfail "empty guard"
+//            | [x] -> guards
+//            | x::xs -> makeMutuallyExclusiveGuards [] [] (List.rev xs)
+//
+//        let rec private symbolizeUnboundedResult source id = function
+//            | NoResult
+//            | Break
+//            | Return Nop -> NoResult
+//            | Return term ->
+//                let resultName = IdGenerator.startingWith(toString id + "%%res") in
+//                // TODO: time!
+//                let result = State.makeSymbolicInstance 0u source resultName (Terms.TypeOf term) in
+//                Return result
+//            | Throw e ->
+//                let resultName = IdGenerator.startingWith(toString id + "%%err") in
+//                // TODO: time!
+//                let error = State.makeSymbolicInstance 0u source resultName (Terms.TypeOf e) in
+//                Throw error
+//            | Guarded gvs ->
+//                let guards, results = List.unzip gvs in
+//                let symbolizedGuards = List.map (fun _ -> VSharp.Constant(IdGenerator.startingWith(toString id + "%%guard"), source, Bool)) guards in
+//                let symbolizedGuards = mutuallyExclusiveGuards symbolizedGuards in
+//                let symbolizedResults = List.map (symbolizeUnboundedResult source id) results in
+//                Guarded(List.zip symbolizedGuards symbolizedResults)
+//            | r -> internalfail ("unexpected result of the unbounded encoding " + toString r)
+//
+//        let internal invokeUnboundedRecursion state id k =
+//            let sourceRef = ref Nop in
+//            let readDepsLocations = readDependencies.[id] |> List.unzip |> fst in
+//            let writeDepsLocations = writeDependencies.[id] in
+//            let readDeps = readDepsLocations |> List.map (Memory.deref state) |> List.unzip |> fst in
+////            let writeDeps, state' = writeDepsLocations |> Memory.symbolizeLocations state sourceRef in
+//            let writeDeps, state' = [], state in
+//
+//            let result = symbolizeUnboundedResult (UnboundedRecursion (TermRef sourceRef)) id unboundedFunctionResult.[id] in
+//            let isSymbolizedConstant _ = function
+//                | Constant (_, UnboundedRecursion (TermRef r), _) as c when LanguagePrimitives.PhysicalEquality r sourceRef -> Some c
+//                | _ -> None
+//            in
+//            let resultConstants = Terms.filterMapConstants isSymbolizedConstant [ControlFlow.resultToTerm result] in
+//            let allResults = List.append resultConstants writeDeps in
+//
+//            let applicationTerm = Expression(Application id, List.append readDeps allResults, Bool) in
+//            sourceRef := applicationTerm
+//            k (result, state')
 
-        let private overwriteReadWriteDependencies id readDeps writeDeps =
-            let currentWriteDeps = writeDependencies.[id] in
-            readDependencies.[id] <- readDeps
-            writeDependencies.[id] <- writeDeps
-            let result = List.length currentWriteDeps = List.length writeDeps
-            unboundedApproximationFinished.[id] <- result
-            result
+        let internal reproduceEffect id state k =
+            k (NoResult, state)
 
-        let private exceptionsFirst (xG, xS) (yG, yS) =
-            match xS, yS with
-            | _ when xS = yS -> 0
-            | Throw _, _ -> -1
-            | _, _ -> 1
-
-        let private bubbleUpExceptions = function
-            | Guarded gvs -> List.sortWith exceptionsFirst gvs |> Guarded
-            | r -> r
-
-        let rec private makeMutuallyExclusiveGuards acc res xs =
-            match xs with
-            | [] -> Terms.MakeNAry OperationType.LogicalAnd (List.map (fun t -> Terms.Negate t) acc) false Bool |> fun g -> g::res
-            | x::xs -> Terms.MakeNAry OperationType.LogicalAnd (x::(List.map (fun t -> Terms.Negate t) acc)) false Bool |> fun g -> makeMutuallyExclusiveGuards (x::acc) (g::res) xs
-
-        let private mutuallyExclusiveGuards guards =
-            match guards with
-            | [] -> internalfail "empty guard"
-            | [x] -> guards
-            | x::xs -> makeMutuallyExclusiveGuards [] [] (List.rev xs)
-
-        let rec private symbolizeUnboundedResult source id = function
-            | NoResult
-            | Break
-            | Return Nop -> NoResult
-            | Return term ->
-                let resultName = IdGenerator.startingWith(toString id + "%%res") in
-                // TODO: time!
-                let result = State.makeSymbolicInstance 0u source resultName (Terms.TypeOf term) in
-                Return result
-            | Throw e ->
-                let resultName = IdGenerator.startingWith(toString id + "%%err") in
-                // TODO: time!
-                let error = State.makeSymbolicInstance 0u source resultName (Terms.TypeOf e) in
-                Throw error
-            | Guarded gvs ->
-                let guards, results = List.unzip gvs in
-                let symbolizedGuards = List.map (fun _ -> VSharp.Constant(IdGenerator.startingWith(toString id + "%%guard"), source, Bool)) guards in
-                let symbolizedGuards = mutuallyExclusiveGuards symbolizedGuards in
-                let symbolizedResults = List.map (symbolizeUnboundedResult source id) results in
-                Guarded(List.zip symbolizedGuards symbolizedResults)
-            | r -> internalfail ("unexpected result of the unbounded encoding " + toString r)
-
-        let internal invokeUnboundedRecursion state id k =
-            let sourceRef = ref Nop in
-            let readDepsLocations = readDependencies.[id] |> List.unzip |> fst in
-            let writeDepsLocations = writeDependencies.[id] in
-            let readDeps = readDepsLocations |> List.map (Memory.deref state) |> List.unzip |> fst in
-//            let writeDeps, state' = writeDepsLocations |> Memory.symbolizeLocations state sourceRef in
-            let writeDeps, state' = [], state in
-
-            let result = symbolizeUnboundedResult (UnboundedRecursion (TermRef sourceRef)) id unboundedFunctionResult.[id] in
-            let isSymbolizedConstant _ = function
-                | Constant (_, UnboundedRecursion (TermRef r), _) as c when LanguagePrimitives.PhysicalEquality r sourceRef -> Some c
-                | _ -> None
-            in
-            let resultConstants = Terms.filterMapConstants isSymbolizedConstant [ControlFlow.resultToTerm result] in
-            let allResults = List.append resultConstants writeDeps in
-
-            let applicationTerm = Expression(Application id, List.append readDeps allResults, Bool) in
-            sourceRef := applicationTerm
-            k (result, state')
-
-        let internal unboundedApproximationState id =
-            if unboundedApproximationFinished.ContainsKey(id) then
-                if (unboundedApproximationFinished.[id]) then Ready
-                else InProgress
-            else NotStarted
-
-        let internal startUnboundedApproximation state id returnType =
-            unboundedApproximationFinished.[id] <- false
-            let symbolicState = state in //Memory.symbolizeState state in
-            unboundedApproximationAttempts.[id] <- 0
-            unboundedApproximationSymbolicState.[id] <- symbolicState
-            readDependencies.[id] <- []
-            writeDependencies.[id] <- []
-            let symbolicResult =
-                match returnType with
-                | Void -> NoResult
-                | _ ->
-                    let resultName = IdGenerator.startingWith(toString id + "%%initial-res") in
-                    // TODO: time!
-                    State.makeSymbolicInstance 0u (UnboundedRecursion (TermRef (ref Nop))) resultName returnType |> Return
-            in unboundedFunctionResult.[id] <- symbolicResult
-            symbolicState
-
-        let internal approximate id result state =
+        let internal approximate id (result, state) =
             let attempt = unboundedApproximationAttempts.[id] + 1 in
             if attempt > Options.WriteDependenciesApproximationTreshold() then
                 failwith "Approximating iterations limit exceeded! Either this is an iternal error or some function is really complex. Consider either increasing approximation treshold or reporing it."
             else
                 unboundedApproximationAttempts.[id] <- attempt
-                let symbolicState = unboundedApproximationSymbolicState.[id] in
-                let writeDependencies = Memory.diff symbolicState state in
-                let writeDependenciesTerms = writeDependencies |> List.map (function | Memory.Mutation (_, t) -> t | Memory.Allocation (_, t) -> t)
-                let result = bubbleUpExceptions result in
-                let readDependencies = findReadDependencies ((ControlFlow.resultToTerm result)::writeDependenciesTerms) in
-                unboundedFunctionResult.[id] <- result
-                overwriteReadWriteDependencies id readDependencies writeDependencies
+                let initialState = initialStates.[id] in
+                true
+//                let writeDependencies = Memory.diff symbolicState state in
+//                let writeDependenciesTerms = writeDependencies |> List.map (function | Memory.Mutation (_, t) -> t | Memory.Allocation (_, t) -> t)
+//                let result = bubbleUpExceptions result in
+//                let readDependencies = findReadDependencies ((ControlFlow.resultToTerm result)::writeDependenciesTerms) in
+//                unboundedFunctionResult.[id] <- result
+//                overwriteReadWriteDependencies id readDependencies writeDependencies
+
+        let rec private doExplore id state this k =
+            interpreter.Invoke id state this (fun result ->
+            if approximate id result then k result
+            else doExplore id state this k)
+
+        let internal explore id k =
+            unboundedApproximationAttempts.[id] <- 0
+            symbolicEffects.[id] <- []
+            let initialSymbolicResult =
+                NoResult
+//                match returnType with
+//                | Void -> NoResult
+//                | _ ->
+//                    let resultName = IdGenerator.startingWith(toString id + "%%initial-res") in
+//                    // TODO: time!
+//                    State.makeSymbolicInstance 0u (UnboundedRecursion (TermRef (ref Nop))) resultName returnType |> Return
+            in symbolicResults.[id] <- initialSymbolicResult
+
+            let this, state =
+                match id with
+                | MetadataMethodIdentifier mm ->
+                    interpreter.InitializeStaticMembers State.empty mm.DeclaringType.AssemblyQualifiedName (fun (_, state) ->
+                    match mm with
+                    | _ when mm.IsStatic -> (None, state)
+                    | _ ->
+                        // TODO: declaring type should be symbolic here
+                        let declaringType = mm.DeclaringType.AssemblyQualifiedName |> System.Type.GetType |> Types.FromDotNetType in
+                        let instance, state = Memory.allocateSymbolicInstance state declaringType in
+                        if Terms.IsHeapRef instance then (Some instance, state)
+                        else
+                            let key = ("external data", mm.Token.ToString()) in
+                            let state = Memory.newStackFrame state [(key, State.Specified instance, declaringType)] in
+                            (Some <| Memory.referenceLocalVariable state key true, state))
+                | DelegateIdentifier ast ->
+                    __notImplemented__()
+                | StandardFunctionIdentifier _ -> __notImplemented__()
+            in initialStates.[id] <- state
+            doExplore id state this k
+
+        let internal exploreIfShould id k =
+            if unboundedApproximationAttempts.ContainsKey id then k ()
+            else
+                explore id (fun _ -> k ())

--- a/VSharp.SILI/State.fs
+++ b/VSharp.SILI/State.fs
@@ -88,10 +88,13 @@ module internal State =
 
 // ------------------------------- Memory level -------------------------------
 
-    [<AllowNullLiteral>]
-    type ActivatorInterface =
+    type IActivator =
         abstract member CreateInstance : System.Type -> Term list -> state -> (Term * state)
-    let mutable activator : ActivatorInterface = null
+    type private NullActivator() =
+        interface IActivator with
+            member this.CreateInstance _ _ _ =
+                internalfail "activator is not ready"
+    let mutable activator : IActivator = new NullActivator() :> IActivator
 
     let rec internal defaultOf time = function
         | Bool -> Terms.MakeFalse


### PR DESCRIPTION
+ Rollback does not exist any more
+ Unbounded encoding is now performed via regular SVM-call (infrastructurally)