### PR TITLE
Cleaning up internal dependencies

### DIFF
--- a/VSharp.CSharpUtils/Tests/ClassesSimple.cs
+++ b/VSharp.CSharpUtils/Tests/ClassesSimple.cs
@@ -158,7 +158,7 @@ namespace VSharp.CSharpUtils.Tests
             ClassesSimpleRegistrator.RegisterAndReturn("ClassesSimpleHierarchyA2(int i, int j) I", j);
         }
 
-        public int GetNum()
+        public new int GetNum()
         {
             return num2;
         }

--- a/VSharp.SILI/Common.fs
+++ b/VSharp.SILI/Common.fs
@@ -32,8 +32,11 @@ module internal Common =
             (Merging.merge (List.zip guardsY values'), state) |> matched)
         | _ -> unmatched x y state matched
 
-    and is metadata (leftType : TermType) (rightType : TermType) =
-        let makeBoolConst name termType = Constant name (SymbolicConstantType termType) Bool Metadata.empty
+    type private SymbolicTypeSource(t : TermType) =
+        inherit SymbolicConstantSource()
+
+    let rec is metadata leftType rightType =
+        let makeBoolConst name termType = Constant name (SymbolicTypeSource termType) Bool Metadata.empty
         in
         let concreteIs (dotNetType : System.Type) =
             let b = makeBoolConst dotNetType.FullName (ClassType(dotNetType, [], [])) in

--- a/VSharp.SILI/Interpreter.fs
+++ b/VSharp.SILI/Interpreter.fs
@@ -1197,7 +1197,7 @@ module internal Interpreter =
         let types, _ = List.unzip typesAndInitializers in
         let time = Memory.tick() in
         let mtd = State.mkMetadata caller state in
-        let fields = List.map (fun t -> State.defaultOf time mtd (FromConcreteMetadataType t), time, time) types
+        let fields = List.map (fun t -> Memory.defaultOf time mtd (FromConcreteMetadataType t), time, time) types
                         |> List.zip (List.map (fun n -> Terms.MakeConcreteString n mtd) names) |> Heap.ofSeq in
         let t = FromConcreteMetadataType constructedType in
         let freshValue = Struct fields t mtd in

--- a/VSharp.SILI/Memory.fs
+++ b/VSharp.SILI/Memory.fs
@@ -21,9 +21,29 @@ module internal Memory =
         pointer := 0
         timestamp := zeroTime
 
+    type private LazyInstantiation(location : Term) =
+        inherit SymbolicConstantSource()
+
     let private isStaticLocation = function
         | StaticRef _ -> true
         | _ -> false
+
+    let rec internal defaultOf time metadata = function
+        | Bool -> MakeFalse metadata
+        | Numeric t when t.IsEnum -> CastConcrete (System.Activator.CreateInstance(t)) t metadata
+        | Numeric t -> CastConcrete 0 t metadata
+        | String -> Terms.Concrete null String metadata
+        | PointerType t -> Concrete null t metadata
+        | ClassType _ as t -> Concrete null t metadata
+        | ArrayType _ as t -> Concrete null t metadata
+        | SubType(dotNetType, _, _,  _) as t when dotNetType.IsValueType -> Struct Heap.empty t metadata
+        | SubType _ as t -> Concrete null t metadata
+        | Func _ -> Concrete null (SubType(typedefof<System.Delegate>, [], [], "func")) metadata
+        | StructType(dotNetType, _, _) as t ->
+            let fields = Types.GetFieldsOf dotNetType false in
+            let contents = Seq.map (fun (k, v) -> (Terms.MakeConcreteString k metadata, (defaultOf time metadata v, time, time))) (Map.toSeq fields) |> Heap.ofSeq in
+            Struct contents t metadata
+        | _ -> __notImplemented__()
 
     let internal mkDefault metadata typ =
         defaultOf (tick()) metadata typ
@@ -40,6 +60,24 @@ module internal Memory =
                                 (key, (value, time, time)))
                 |> Heap.ofSeq
         fields, t, Struct contents t metadata
+
+    let internal makeSymbolicInstance metadata time source name = function
+        | PointerType t ->
+            let constant = Constant name source pointerType metadata in
+            HeapRef ((constant, t), []) time metadata
+        | t when Types.IsPrimitive t || Types.IsFunction t -> Constant name source t metadata
+        | StructType _
+        | SubType _
+        | ClassType _ as t -> Struct Heap.empty t metadata
+        | ArrayType(e, d) as t -> VSharp.Array.makeSymbolic metadata source d t name
+        | _ -> __notImplemented__()
+
+    let internal genericLazyInstantiator =
+        let instantiator metadata time fullyQualifiedLocation typ () =
+            makeSymbolicInstance metadata time (LazyInstantiation fullyQualifiedLocation) (nameOfLocation fullyQualifiedLocation) typ
+        in
+        State.genericLazyInstantiator <- instantiator
+        instantiator
 
     let rec private referenceSubLocation location term =
         match term.term with

--- a/VSharp.SILI/State.fs
+++ b/VSharp.SILI/State.fs
@@ -22,7 +22,7 @@ module internal State =
         | Specified of 'a
         | Unspecified
 
-    let private nameOfLocation = term >> function
+    let internal nameOfLocation = term >> function
         | HeapRef((_, (x, _)::xs), _) -> toString x
         | HeapRef(((_, t), _), _) -> toString t
         | StackRef((name, _), x::_) -> sprintf "%s.%O" name x
@@ -125,57 +125,8 @@ module internal State =
             member this.CreateInstance _ _ _ _ =
                 internalfail "activator is not ready"
     let mutable activator : IActivator = new NullActivator() :> IActivator
-
-    let rec internal defaultOf time metadata = function
-        | Bool -> MakeFalse metadata
-        | Numeric t when t.IsEnum -> CastConcrete (System.Activator.CreateInstance(t)) t metadata
-        | Numeric t -> CastConcrete 0 t metadata
-        | String -> Terms.Concrete null String metadata
-        | PointerType t -> Concrete null t metadata
-        | ClassType _ as t -> Concrete null t metadata
-        | ArrayType _ as t -> Concrete null t metadata
-        | SubType(dotNetType, _, _,  _) as t when dotNetType.IsValueType -> Struct Heap.empty t metadata
-        | SubType _ as t -> Concrete null t metadata
-        | Func _ -> Concrete null (SubType(typedefof<System.Delegate>, [], [], "func")) metadata
-        | StructType(dotNetType, _, _) as t ->
-            let fields = Types.GetFieldsOf dotNetType false in
-            let contents = Seq.map (fun (k, v) -> (Terms.MakeConcreteString k metadata, (defaultOf time metadata v, time, time))) (Map.toSeq fields) |> Heap.ofSeq in
-            Struct contents t metadata
-        | _ -> __notImplemented__()
-
-    let internal arrayLengthType = typedefof<int>
-    let internal arrayLengthTermType = Numeric arrayLengthType in
-
-    let internal mkArrayZeroLowerBound metadata rank =
-        FSharp.Collections.Array.init rank (Concrete 0 arrayLengthTermType metadata |> always)
-
-    let internal mkArraySymbolicLowerBound metadata array arrayName rank =
-        match Options.SymbolicArrayLowerBoundStrategy() with
-        | Options.AlwaysZero -> mkArrayZeroLowerBound metadata rank
-        | Options.AlwaysSymbolic ->
-            FSharp.Collections.Array.init rank (fun i ->
-                let idOfBound = sprintf "lower bound of %s" arrayName |> IdGenerator.startingWith in
-                Constant idOfBound (SymbolicArrayLength(array, i, false)) arrayLengthTermType metadata)
-
-    let internal makeSymbolicArray metadata source rank typ name =
-        let idOfLength = IdGenerator.startingWith (sprintf "|%s|" name) in
-        let constant = Constant name source typ metadata in
-        let lengths = FSharp.Collections.Array.init rank (fun i -> Constant idOfLength (SymbolicArrayLength(constant, i, true)) (Numeric arrayLengthType) metadata) in
-        Array (mkArraySymbolicLowerBound metadata constant name rank) (Some constant) Heap.empty lengths typ metadata
-
-    let internal makeSymbolicInstance metadata time source name = function
-        | PointerType t ->
-            let constant = Constant name source pointerType metadata in
-            HeapRef ((constant, t), []) time metadata
-        | t when Types.IsPrimitive t || Types.IsFunction t -> Constant name source t metadata
-        | StructType _
-        | SubType _
-        | ClassType _ as t -> Struct Heap.empty t metadata
-        | ArrayType(e, d) as t -> makeSymbolicArray metadata source d t name
-        | _ -> __notImplemented__()
-
-    let internal genericLazyInstantiator metadata time fullyQualifiedLocation typ () =
-        makeSymbolicInstance metadata time (LazyInstantiation fullyQualifiedLocation) (nameOfLocation fullyQualifiedLocation) typ
+    let mutable genericLazyInstantiator : TermMetadata -> Timestamp -> Term -> TermType -> unit -> Term =
+        fun _ _ _ _ () -> internalfailf "generic lazy instantiator is not ready"
 
     let internal stackLazyInstantiator state time key =
         let time = frameTime state key in

--- a/VSharp.SILI/Terms.fs
+++ b/VSharp.SILI/Terms.fs
@@ -135,11 +135,10 @@ and
             | :? Term as other -> this.term.Equals(other.term)
             | _ -> false
 
-and SymbolicConstantSource =
-    | UnboundedRecursion of TermRef
-    | LazyInstantiation of Term
-    | SymbolicArrayLength of Term * int * bool // (Array constant) * dimension * (length if true or lower bound if false)
-    | SymbolicConstantType of TermType
+and SymbolicConstantSource() =
+    override this.GetHashCode() =
+        this.GetType().GetHashCode()
+    override this.Equals(o : obj) = o.GetType() = this.GetType()
 
 and SymbolicHeap = Heap<Term, Term>
 
@@ -411,13 +410,6 @@ module public Terms =
     let rec private addConstants mapper (visited : HashSet<Term>) acc term =
         match term.term with
         | Constant(name, source, t) when visited.Add(term) ->
-            let acc =
-                match source with
-                | UnboundedRecursion app -> addConstants mapper visited acc !app.reference
-                | LazyInstantiation loc -> addConstants mapper visited acc loc
-                | SymbolicArrayLength(arr, _, _) -> addConstants mapper visited acc arr
-                | SymbolicConstantType _ -> acc
-            in
             match mapper acc term with
             | Some value -> value::acc
             | None -> acc

--- a/VSharp.Test/Tests/VSharp.CSharpUtils/Unix.gold
+++ b/VSharp.Test/Tests/VSharp.CSharpUtils/Unix.gold
@@ -2784,7 +2784,7 @@ RESULT: UNION[
 HEAP:
 1 ==> STRUCT VSharp.CSharpUtils.Tests.Piece[
 	| VSharp.CSharpUtils.Tests.Piece.Rate ~> UNION[
-		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) & (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) & 1 == obj ~> VSharp.CSharpUtils.Tests.Piece.Rate]]
+		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) & 1 == obj ~> VSharp.CSharpUtils.Tests.Piece.Rate]]
 10 ==> UNION[
 	| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) ~> STRUCT System.Runtime.Serialization.SafeSerializationManager[
 	| System.Runtime.Serialization.SafeSerializationManager.m_realObject ~> null
@@ -2878,7 +2878,7 @@ HEAP:
 obj ==> UNION[
 	| !(0 == obj) & (!(1 == obj) | !VSharp.CSharpUtils.Tests.Piece & System.Object1) & (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) ~> STRUCT <Subtype of System.Object>[
 	| VSharp.CSharpUtils.Tests.Piece.Rate ~> VSharp.CSharpUtils.Tests.Piece.Rate]
-	| !VSharp.CSharpUtils.Tests.Piece & System.Object1 | (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) & (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) & 1 == obj | 0 == obj ~> STRUCT <Subtype of System.Object>[
+	| !VSharp.CSharpUtils.Tests.Piece & System.Object1 | (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) & 1 == obj | 0 == obj ~> STRUCT <Subtype of System.Object>[
 	]]
 System.Environment ==> STRUCT System.Environment[
 	| System.Environment.mono_corlib_version ~> 1050200001

--- a/VSharp.Test/Tests/VSharp.CSharpUtils/Win32NT.gold
+++ b/VSharp.Test/Tests/VSharp.CSharpUtils/Win32NT.gold
@@ -3337,7 +3337,7 @@ RESULT: UNION[
 HEAP:
 1 ==> STRUCT VSharp.CSharpUtils.Tests.Piece[
 	| VSharp.CSharpUtils.Tests.Piece.Rate ~> UNION[
-		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) & (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) & 1 == obj ~> VSharp.CSharpUtils.Tests.Piece.Rate]]
+		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) & 1 == obj ~> VSharp.CSharpUtils.Tests.Piece.Rate]]
 10 ==> UNION[
 	| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) ~> STRUCT System.Runtime.Serialization.SafeSerializationManager[
 	| System.Runtime.Serialization.SafeSerializationManager.m_realObject ~> null
@@ -3455,7 +3455,7 @@ HEAP:
 obj ==> UNION[
 	| !(0 == obj) & (!(1 == obj) | !VSharp.CSharpUtils.Tests.Piece & System.Object1) & (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) ~> STRUCT <Subtype of System.Object>[
 	| VSharp.CSharpUtils.Tests.Piece.Rate ~> VSharp.CSharpUtils.Tests.Piece.Rate]
-	| !VSharp.CSharpUtils.Tests.Piece & System.Object1 | (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) & (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) & 1 == obj | 0 == obj ~> STRUCT <Subtype of System.Object>[
+	| !VSharp.CSharpUtils.Tests.Piece & System.Object1 | (!System.Object1 | VSharp.CSharpUtils.Tests.Piece) & 1 == obj | 0 == obj ~> STRUCT <Subtype of System.Object>[
 	]]
 System.Environment ==> STRUCT System.Environment[
 	| System.Environment.MaxEnvVariableValueLength ~> 32767


### PR DESCRIPTION
+ SymbolicConstantSource is now .NET class with private inheritors  in separate modules
+ makeSymbolicInstance, defaultOf moved back to Memory.fs
+ makeSymbolicArray, arrayLength, etc. moved back to Array.fs

Signed-off-by: Dmitry Mordvinov <dvvsrd@gmail.com>