### PR TITLE
Small refactoring for operators subsystem

### DIFF
--- a/VSharp.CSharpUtils/Tests/ClassesSimple.cs
+++ b/VSharp.CSharpUtils/Tests/ClassesSimple.cs
@@ -30,7 +30,7 @@ namespace VSharp.CSharpUtils.Tests
 
         public int GetN()
         {
-            return this._b.GetN();
+            return _b.GetN();
         }
     }
 

--- a/VSharp.CSharpUtils/Tests/Typecast.cs
+++ b/VSharp.CSharpUtils/Tests/Typecast.cs
@@ -231,8 +231,8 @@ namespace VSharp.CSharpUtils.Tests.Typecast
 
         public Employee(string name, int jobGrade)
         {
-            this.Name = name;
-            this.JobGrade = jobGrade;
+            Name = name;
+            JobGrade = jobGrade;
         }
 
         public override string ToString()

--- a/VSharp.SILI/Arithmetics.fs
+++ b/VSharp.SILI/Arithmetics.fs
@@ -9,6 +9,7 @@ open Types.Constructor
 
 [<AutoOpen>]
 module internal Arithmetics =
+
     let private makeAddition mtd isChecked state t x y k =
         (MakeBinary OperationType.Add x y isChecked (FromConcreteDotNetType t) mtd, state) |> k
 
@@ -18,8 +19,6 @@ module internal Arithmetics =
     let private makeShift mtd op state isChecked t x y k =
         (MakeBinary op x y isChecked (FromConcreteDotNetType t) mtd, state) |> k
 
-    let simplifyConcreteBinary simplify mtd isChecked t x y xval yval _ _ state =
-        simplify (Metadata.combine3 mtd x.metadata y.metadata) isChecked state t xval yval
 // ------------------------------- Simplification of "+" -------------------------------
 
     let private simplifyConcreteAddition mtd isChecked state t x y =
@@ -382,7 +381,7 @@ module internal Arithmetics =
         let success = ref true
         Calculator.IsZero(Calculator.Rem(x, y, t, success)) && !success
 
-    and private simplifyRemainder mtd isChecked state t x y k =
+    and internal simplifyRemainder mtd isChecked state t x y k =
         let defaultCase () =
             let sorted = if not isChecked && (IsConcrete y) then (y, x) else (x, y)
             makeProduct mtd isChecked state t (fst sorted) (snd sorted) k
@@ -551,12 +550,6 @@ module internal Arithmetics =
 
     let eq mtd x y =
         simplifyEqual mtd x y id
-
-    let (+++) x y = add Metadata.empty x y
-    let (---) x y = sub Metadata.empty x y
-    let ( *** ) x y = mul Metadata.empty x y
-    let (%%%) x y = rem Metadata.empty x y
-    let (===) x y = eq Metadata.empty x y
 
     let internal simplifyBinaryOperation metadata op state x y isChecked t k =
         match op with

--- a/VSharp.SILI/Common.fs
+++ b/VSharp.SILI/Common.fs
@@ -8,6 +8,9 @@ module internal Common =
 
     let internal simplifyPairwiseCombinations = Propositional.simplifyPairwiseCombinations
 
+    let internal simplifyConcreteBinary simplify mtd isChecked t x y xval yval _ _ state =
+        simplify (Metadata.combine3 mtd x.metadata y.metadata) isChecked state t xval yval
+
     let rec internal simplifyGenericUnary name state x matched concrete unmatched =
         match x.term with
         | Error _ -> matched (x, state)

--- a/VSharp.SILI/ControlFlow.fs
+++ b/VSharp.SILI/ControlFlow.fs
@@ -12,13 +12,13 @@ and
     [<CustomEquality;NoComparison>]
     StatementResult =
         {result : StatementResultNode; metadata : TermMetadata}
-        override this.ToString() =
-            this.result.ToString()
-        override this.GetHashCode() =
-            this.result.GetHashCode()
-        override this.Equals(o : obj) =
+        override x.ToString() =
+            x.result.ToString()
+        override x.GetHashCode() =
+            x.result.GetHashCode()
+        override x.Equals(o : obj) =
             match o with
-            | :? StatementResult as other -> this.result.Equals(other.result)
+            | :? StatementResult as other -> x.result.Equals(other.result)
             | _ -> false
 
 [<AutoOpen>]

--- a/VSharp.SILI/Extern/SDK.fs
+++ b/VSharp.SILI/Extern/SDK.fs
@@ -34,6 +34,7 @@ module ExternSDK =
     let simplifyLessOrEqual x y k = Arithmetics.simplifyLessOrEqual (m()) x y k
     let simplifyGreater x y k = Arithmetics.simplifyGreater (m()) x y k
     let simplifyGreaterOrEqual x y k = Arithmetics.simplifyGreaterOrEqual (m()) x y k
+    let simplifyRemainder isChecked state t x y k = Arithmetics.simplifyRemainder (m()) isChecked state t x y k
 
     let simplifyAnd x y k = Propositional.simplifyAnd (m()) x y k
     let simplifyOr x y k = Propositional.simplifyOr (m()) x y k

--- a/VSharp.SILI/Extern/System/Math.fs
+++ b/VSharp.SILI/Extern/System/Math.fs
@@ -7,6 +7,9 @@ open VSharp
 
 module private MathImpl =
 
+    let (===) t1 t2 = simplifyEqual t1 t2 id
+    let (%%%) t1 t2 = simplifyRemainder false State.empty (t1 |> TypeOf |> Types.ToDotNetType) t1 t2 fst
+
     let impl<'a when 'a : comparison> (concrete: ('a -> 'a)) standFunc (state : State.state) args =
         let arg = List.item 0 args in
         let rec impl term =

--- a/VSharp.SILI/Functions.fs
+++ b/VSharp.SILI/Functions.fs
@@ -46,9 +46,9 @@ module Functions =
             abstract member Invoke : FunctionIdentifier -> State.state -> Term option -> (StatementResult * State.state -> 'a) -> 'a
         type private NullActivator() =
             interface IInterpreter with
-                member this.InitializeStaticMembers _ _ _ =
+                member x.InitializeStaticMembers _ _ _ =
                     internalfail "interpreter for unbounded recursion is not ready"
-                member this.Invoke _ _ _ _ =
+                member x.Invoke _ _ _ _ =
                     internalfail "interpreter for unbounded recursion is not ready"
         let mutable interpreter : IInterpreter = new NullActivator() :> IInterpreter
 

--- a/VSharp.SILI/Operations.fs
+++ b/VSharp.SILI/Operations.fs
@@ -151,8 +151,8 @@ module Operations =
         | Power
         | Absolute
         | AbsoluteS
-        override this.ToString() =
-            match this with
+        override x.ToString() =
+            match x with
             | Arccosine -> "arccos"
             | Arcsine -> "arcsin"
             | Arctangent -> "arctan"

--- a/VSharp.SILI/Operators.fs
+++ b/VSharp.SILI/Operators.fs
@@ -1,0 +1,34 @@
+namespace VSharp
+
+[<AutoOpen>]
+module internal Operators =
+
+    let simplifyBinaryOperation mtd op isChecked state t left right k =
+        let t1 = Terms.TypeOf left in
+        let t2 = Terms.TypeOf right in
+        match op with
+        | op when Propositional.isLogicalOperation op t1 t2 ->
+            Propositional.simplifyBinaryConnective mtd op left right (withSnd state >> k)
+        | op when Arithmetics.isArithmeticalOperation op t1 t2 ->
+            Arithmetics.simplifyBinaryOperation mtd op state left right isChecked t k
+        | op when Strings.isStringOperation op t1 t2 ->
+            Strings.simplifyOperation mtd op left right |> (withSnd state >> k)
+        | op when Pointers.isPointerOperation op t1 t2 ->
+            Pointers.simplifyBinaryOperation mtd op state left right k
+        | _ -> __notImplemented__()
+
+    let ksimplifyEquality mtd x y k =
+        simplifyBinaryOperation mtd JetBrains.Decompiler.Ast.OperationType.Equal false State.empty typeof<bool> x y (fst >> k)
+
+    let simplifyEquality mtd x y =
+        ksimplifyEquality mtd x y id
+
+    let (===) x y = ksimplifyEquality Metadata.empty x y id
+    let (!==) x y = ksimplifyEquality Metadata.empty x y (!!)
+
+    let simplifyUnaryOperation mtd op isChecked state t arg k =
+        match t with
+        | Bool -> Propositional.simplifyUnaryConnective mtd op arg (withSnd state >> k)
+        | Numeric t -> Arithmetics.simplifyUnaryOperation mtd op state arg isChecked t k
+        | String -> __notImplemented__()
+        | _ -> __notImplemented__()

--- a/VSharp.SILI/Pointers.fs
+++ b/VSharp.SILI/Pointers.fs
@@ -1,0 +1,56 @@
+namespace VSharp
+
+open JetBrains.Decompiler.Ast
+open VSharp.Common
+
+module internal Pointers =
+
+    let internal locationEqual mtd addr1 addr2 =
+        match TypeOf addr1, TypeOf addr2 with
+        | String, String -> Strings.simplifyEquality mtd addr1 addr2
+        | Numeric _, Numeric _ -> Arithmetics.eq mtd addr1 addr2
+        | _ -> __notImplemented__()
+
+    let internal comparePath mtd path1 path2 =
+        if List.length path1 <> List.length path2 then
+            Terms.MakeFalse mtd
+        else
+            List.map2 (fun (x, _) (y, _) -> locationEqual mtd x y) path1 path2 |> conjunction mtd
+
+    let rec internal simplifyReferenceEquality mtd x y k =
+        simplifyGenericBinary "reference comparison" State.empty x y (fst >> k)
+            (fun _ _ _ _ -> __unreachable__())
+            (fun x y s k ->
+                let k = withSnd s >> k in
+                match x.term, y.term with
+                | _ when x = y -> MakeTrue mtd |> k
+                | HeapRef(xpath, _), HeapRef(ypath, _) ->
+                    comparePath mtd (NonEmptyList.toList xpath) (NonEmptyList.toList ypath) |> k
+                | StackRef(key1, path1), StackRef(key2, path2) ->
+                    MakeBool (key1 = key2) mtd &&& comparePath mtd path1 path2 |> k
+                | StaticRef(key1, path1), StaticRef(key2, path2) ->
+                    MakeBool (key1 = key2) mtd &&& comparePath mtd path1 path2 |> k
+                | _ -> MakeFalse mtd |> k)
+            (fun x y state k -> simplifyReferenceEquality mtd x y (withSnd state >> k))
+
+    let internal isNull mtd ptr =
+        simplifyReferenceEquality mtd ptr (MakeNull Null mtd State.zeroTime) id
+
+    let internal simplifyBinaryOperation metadata op state x y k =
+        match op with
+        | OperationType.Add
+        | OperationType.Subtract -> __notImplemented__()
+        | OperationType.Equal -> simplifyReferenceEquality metadata x y (withSnd state >> k)
+        | OperationType.NotEqual ->
+            simplifyReferenceEquality metadata x y (fun e ->
+            Propositional.simplifyNegation metadata e (withSnd state >> k))
+        | _ -> internalfailf "%O is not a binary arithmetical operator" op
+
+    let internal isPointerOperation op t1 t2 =
+        (Types.IsPointer t1 || Types.IsBottom t1) && (Types.IsPointer t2 || Types.IsBottom t2) &&
+        match op with
+        | OperationType.Add
+        | OperationType.Subtract
+        | OperationType.Equal
+        | OperationType.NotEqual -> true
+        | _ -> false

--- a/VSharp.SILI/Propositional.fs
+++ b/VSharp.SILI/Propositional.fs
@@ -201,11 +201,11 @@ module internal Propositional =
     let internal (|||) x y =
         simplifyOr Metadata.empty x y id
 
-    let internal (===) x y =
+    let internal eq x y =
         simplifyOr Metadata.empty !!x y (fun x' -> simplifyOr Metadata.empty x !!y (fun y' -> simplifyAnd Metadata.empty x' y' id))
 
-    let internal (!==) x y =
-        !! (x === y)
+    let internal neq x y =
+        !! (eq x y)
 
     let internal implies x y mtd =
         simplifyNegation mtd x (fun notX ->

--- a/VSharp.SILI/Terms.fs
+++ b/VSharp.SILI/Terms.fs
@@ -10,8 +10,8 @@ type FunctionIdentifier =
     | MetadataMethodIdentifier of JetBrains.Metadata.Reader.API.IMetadataMethod
     | DelegateIdentifier of JetBrains.Decompiler.Ast.INode
     | StandardFunctionIdentifier of Operations.StandardFunction
-    override this.ToString() =
-        match this with
+    override x.ToString() =
+        match x with
         | MetadataMethodIdentifier mm -> mm.Name
         | DelegateIdentifier _ -> "<delegate>"
         | StandardFunctionIdentifier sf -> sf.ToString()
@@ -20,16 +20,16 @@ type StackKey = string * string  // Name and token
 
 type LocationBinding = JetBrains.Decompiler.Ast.INode
 type StackHash = int list
-type TermMetadataEntry = {location : LocationBinding; stack : StackHash}
-type TermMetadata = TermMetadataEntry list
+type TermOrigin = { location : LocationBinding; stack : StackHash }
+type TermMetadata = { origins : TermOrigin list; mutable misc : HashSet<obj> }
 
 [<StructuralEquality;NoComparison>]
 type public Operation =
     | Operator of OperationType * bool
     | Application of FunctionIdentifier
     | Cast of TermType * TermType * bool
-    member this.priority =
-        match this with
+    member x.priority =
+        match x with
         | Operator (op, _) -> Operations.operationPriority op
         | Application _ -> Operations.maxPriority
         | Cast _ -> Operations.maxPriority - 1
@@ -52,7 +52,7 @@ type public TermNode =
     | StaticRef of string * (Term * TermType) list
     | Union of (Term * Term) list
 
-    override this.ToString() =
+    override x.ToString() =
         let checkExpression curChecked parentChecked priority parentPriority str =
             match curChecked, parentChecked with
             | true, _ when curChecked <> parentChecked -> sprintf "checked(%s)" str
@@ -130,36 +130,37 @@ type public TermNode =
             | _ when String.IsNullOrEmpty stringResult -> stringResult
             | _ -> "\n" + parentIndent + stringResult + separator
 
-        toStr -1 false "\t" this
+        toStr -1 false "\t" x
 
 and
     [<CustomEquality;NoComparison>]
     TermRef =
         {reference : Term ref}
-        override this.GetHashCode() =
-            Microsoft.FSharp.Core.LanguagePrimitives.PhysicalHash(this)
-        override this.Equals(o : obj) =
+        override x.GetHashCode() =
+            Microsoft.FSharp.Core.LanguagePrimitives.PhysicalHash(x)
+        override x.Equals(o : obj) =
             match o with
-            | :? TermRef as other -> this.GetHashCode() = other.GetHashCode()
+            | :? TermRef as other -> x.GetHashCode() = other.GetHashCode()
             | _ -> false
 
 and
     [<CustomEquality;NoComparison>]
     Term =
         {term : TermNode; metadata : TermMetadata}
-        override this.ToString() =
-            this.term.ToString()
-        override this.GetHashCode() =
-            this.term.GetHashCode()
-        override this.Equals(o : obj) =
+        override x.ToString() =
+            x.term.ToString()
+        override x.GetHashCode() =
+            x.term.GetHashCode()
+        override x.Equals(o : obj) =
             match o with
-            | :? Term as other -> this.term.Equals(other.term)
+            | :? Term as other -> x.term.Equals(other.term)
             | _ -> false
 
 and SymbolicConstantSource() =
-    override this.GetHashCode() =
-        this.GetType().GetHashCode()
-    override this.Equals(o : obj) = o.GetType() = this.GetType()
+    override x.GetHashCode() =
+        x.GetType().GetHashCode()
+    override x.Equals(o : obj) =
+        o.GetType() = x.GetType()
 
 and SymbolicHeap = Heap<Term, Term>
 
@@ -167,9 +168,14 @@ and SymbolicHeap = Heap<Term, Term>
 module public Terms =
 
     module Metadata =
-        let empty = List.empty
-        let combine m1 m2 = List.append m1 m2 |> List.distinct
-        let combine3 m1 m2 m3 = List.append3 m1 m2 m3 |> List.distinct
+        let empty = { origins = List.empty; misc = null }
+        let combine m1 m2 = { origins = List.append m1.origins m2.origins |> List.distinct; misc = null }
+        let combine3 m1 m2 m3 = { origins = List.append3 m1.origins m2.origins m3.origins |> List.distinct; misc = null }
+        let addMisc t obj =
+            if t.metadata.misc = null then t.metadata.misc <- new HashSet<obj>()
+            t.metadata.misc.Add obj |> ignore
+        let isEmpty m = List.isEmpty m.origins
+        let firstOrigin m = List.head m.origins
 
     let public term (term : Term) = term.term
 

--- a/VSharp.SILI/Types.fs
+++ b/VSharp.SILI/Types.fs
@@ -11,7 +11,7 @@ type public Variance =
     | Covariant
     | Invarinat
 
-[<StructuralEquality;NoComparison>] 
+[<StructuralEquality;NoComparison>]
 type public TermType =
     | Void
     | Bottom
@@ -26,8 +26,8 @@ type public TermType =
     | Func of TermType list * TermType
     | PointerType of TermType
 
-    override this.ToString() =
-        match this with
+    override x.ToString() =
+        match x with
         | Void -> "void"
         | Bottom -> "exception"
         | Null -> "<nullType>"
@@ -44,11 +44,11 @@ type public TermType =
 and [<CustomEquality;NoComparison>]
     TermTypeRef =
         | TermTypeRef of TermType ref
-        override this.GetHashCode() =
-            Microsoft.FSharp.Core.LanguagePrimitives.PhysicalHash(this)
-        override this.Equals(o : obj) =
+        override x.GetHashCode() =
+            Microsoft.FSharp.Core.LanguagePrimitives.PhysicalHash(x)
+        override x.Equals(o : obj) =
             match o with
-            | :? TermTypeRef as other -> this.GetHashCode() = other.GetHashCode()
+            | :? TermTypeRef as other -> x.GetHashCode() = other.GetHashCode()
             | _ -> false
 
 module public Types =
@@ -242,9 +242,9 @@ module public Types =
             | _ -> Type.GetType(arg.AssemblyQualifiedName, true)
 
         let private StructType (t : Type) g i = StructType(Hierarchy t, g, i)
-        
+
         let private ClassType (t : Type) g i = ClassType(Hierarchy t, g, i)
-        
+
         let private SubType (t : Type) g i name = SubType(Hierarchy t, g, i, name)
 
         module private TypesCache =
@@ -409,18 +409,18 @@ module public Types =
         let public FromUniqueSymbolicMetadataType (t : IMetadataType) = FromMetadataType Unique t
 
         let public FromGlobalSymbolicMetadataType t = FromMetadataType Global t
-        
+
         let (|StructureType|_|) = function
             | TermType.StructType(t, genArg, interfaces) -> Some(StructureType(t, genArg, interfaces))
             | Numeric t -> Some(StructureType(Hierarchy t, [], getInterfaces Global t))
             | Bool -> Some(StructureType(Hierarchy typedefof<bool>, [], getInterfaces Global typedefof<bool>))
             | _ -> None
-        
+
         let (|ReferenceType|_|) = function
             | String -> Some(ReferenceType(Hierarchy typedefof<string>, [], getInterfaces Global typedefof<string>))
             | TermType.ClassType(t, genArg, interfaces) -> Some(ReferenceType(t, genArg, interfaces))
             | _ -> None
-        
+
         let (|ComplexType|_|) = function
             | StructureType(t, genArg, interfaces)
             | ReferenceType(t, genArg, interfaces) -> Some(ComplexType(t, genArg, interfaces))

--- a/VSharp.SILI/VSharp.SILI.fsproj
+++ b/VSharp.SILI/VSharp.SILI.fsproj
@@ -64,6 +64,8 @@
     <Compile Include="Common.fs" />
     <Compile Include="Arithmetics.fs" />
     <Compile Include="Strings.fs" />
+    <Compile Include="Pointers.fs" />
+    <Compile Include="Operators.fs" />
     <Compile Include="Array.fs" />
     <Compile Include="Memory.fs" />
     <Compile Include="Transformations.fs" />
@@ -117,7 +119,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/VSharp.Utils/Hierarchy.fs
+++ b/VSharp.Utils/Hierarchy.fs
@@ -21,11 +21,11 @@ module public Hierarchy =
     let private make t = getInheritanceHierarchy t
 
     type public Hierarchy(hierarchy : System.Type list) =
-        member this.Inheritor = List.head hierarchy
-        member this.Hierarchy = hierarchy
-        member this.Name = this.Inheritor.ToString()
-        member this.Is (r : Hierarchy) = Seq.contains r.Inheritor hierarchy
-        member this.Equals (r : Hierarchy) = this.Inheritor = r.Inheritor
-        member this.Equals (r : System.Type) = this.Inheritor = r
+        member x.Inheritor = List.head hierarchy
+        member x.Hierarchy = hierarchy
+        member x.Name = x.Inheritor.ToString()
+        member x.Is (r : Hierarchy) = Seq.contains r.Inheritor hierarchy
+        member x.Equals (r : Hierarchy) = x.Inheritor = r.Inheritor
+        member x.Equals (r : System.Type) = x.Inheritor = r
         new (typ : System.Type) = Hierarchy(make typ)
-        override this.ToString() = this.Name
+        override x.ToString() = x.Name


### PR DESCRIPTION
+ pointer comparison moved to Pointers.fs
+ generic unary and binary operations on terms are now in Operators.fs
+ term metadata now contains storage for miscellanious data
+ lazy instantiation source now can be top level address of the
   heap reference
+ 'this' renamed to 'x' all over the codebase

Signed-off-by: Dmitry Mordvinov <dvvsrd@gmail.com>