### PR TITLE
Ptr types

### DIFF
--- a/VSharp.CSharpUtils/Tests/Unsafe.cs
+++ b/VSharp.CSharpUtils/Tests/Unsafe.cs
@@ -40,5 +40,11 @@ namespace VSharp.CSharpUtils.Tests
             int* p = &x;
             return **&p;
         }
+
+        public static int ReturnIntFromIntPtr(int myFavouriteParameter)
+        {
+            var s = new IntPtr(&myFavouriteParameter);
+            return *(int*) s.ToPointer();
+        }
     }
 }

--- a/VSharp.CSharpUtils/Tests/Unsafe.cs
+++ b/VSharp.CSharpUtils/Tests/Unsafe.cs
@@ -27,5 +27,11 @@ namespace VSharp.CSharpUtils.Tests
         {
             return sizeof(FixedSizedBuffer); // sizeof() = 70; Marshal.SizeOf() = 72; we should behave like sizeof()
         }
+
+        public static int ReturnConst()
+        {
+            int x = 421234123;
+            return *&x;
+        }
     }
 }

--- a/VSharp.CSharpUtils/Tests/Unsafe.cs
+++ b/VSharp.CSharpUtils/Tests/Unsafe.cs
@@ -33,5 +33,12 @@ namespace VSharp.CSharpUtils.Tests
             int x = 421234123;
             return *&x;
         }
+
+        public static int DoubleIndirection()
+        {
+            int x = 428999;
+            int* p = &x;
+            return **&p;
+        }
     }
 }

--- a/VSharp.SILI/Common.fs
+++ b/VSharp.SILI/Common.fs
@@ -79,6 +79,7 @@ module internal Common =
         | leftType, (StructureType(t, _, _) as termType)
         | leftType, (ReferenceType(t, _, _) as termType) -> concreteIs t termType leftType
         | leftType, (SubType(t, _, _, name) as termType) -> subTypeIs t termType name leftType
+        | Pointer _, Pointer _ -> Terms.MakeTrue metadata
         | _ -> Terms.MakeFalse metadata
 
     let internal simpleConditionalExecution conditionInvocation thenBranch elseBranch merge merge2 k =

--- a/VSharp.SILI/Interpreter.fs
+++ b/VSharp.SILI/Interpreter.fs
@@ -984,21 +984,19 @@ module internal Interpreter =
         reduceExpression state ast.Argument (fun (term, state) ->
         let mtd = State.mkMetadata ast state in
         let isCasted state term = checkCast mtd state targetType term in
-        let mapper state term targetType =
+        let mapper state term targetType k =
             reduceConditionalStatements state
                 (fun state k -> k (isCasted state term))
                 (fun state k -> k (doCast mtd term targetType false, state))
                 (fun state k -> k (ifNotCasted mtd state term targetType))
-                (fun (statementResult, state) -> (ControlFlow.resultToTerm statementResult, state))
+                (fun (statementResult, state) -> k (ControlFlow.resultToTerm statementResult, state))
         in
-        let term, state =
-            match term.term with
-            | Union gvs -> Merging.guardedStateMap (fun state term -> mapper state term targetType) gvs state
-            | _ -> mapper state term targetType
-        in k (term, state))
+        match term.term with
+        | Union gvs -> Merging.guardedStateMapk (fun state term k -> mapper state term targetType k) gvs state k
+        | _ -> mapper state term targetType k)
 
     and reduceTypeCastExpression state (ast : ITypeCastExpression) k =
-        let isChecked = ast.OverflowCheck = OverflowCheckType.Enabled
+        let isChecked = ast.OverflowCheck = OverflowCheckType.Enabled in
         let mtd = State.mkMetadata ast state in
         let cast src dst expr =
             if src = dst then expr
@@ -1006,37 +1004,35 @@ module internal Interpreter =
         in
         let targetType = FromGlobalSymbolicMetadataType ast.TargetType in
         let isCasted state term = checkCast mtd state targetType term in
-        let hierarchyCast state term targetType =
+        let hierarchyCast state term targetType k =
             reduceConditionalStatements state
                 (fun state k -> k (isCasted state term))
                 (fun state k -> k (doCast mtd term targetType isChecked, state))
                 (fun state k -> k (throwInvalidCastException mtd state term targetType))
-                (fun (statementResult, state) -> (ControlFlow.resultToTerm statementResult, state))
+                (fun (statementResult, state) -> k (ControlFlow.resultToTerm statementResult, state))
         in
-        let rec primitiveCast state term targetType =
+        let primitiveCast state term targetType k =
             match term.term with
-            | Error _ -> term, state
+            | Error _ -> k (term, state)
             | Nop -> internalfailf "casting void to %O!" targetType
-            | _ when Terms.IsNull term -> Terms.MakeNullRef targetType mtd, state
+            | _ when Terms.IsNull term -> k (Terms.MakeNullRef targetType mtd, state)
             | Concrete(value, _) ->
                 if Terms.IsFunction term && Types.IsFunction targetType
-                then (Concrete value targetType term.metadata, state)
-                else (CastConcrete value (Types.ToDotNetType targetType) term.metadata, state)
-            | Constant(_, _, t) -> (cast t targetType term, state)
-            | Expression(operation, operands, t) -> (cast t targetType term, state)
+                then k (Concrete value targetType term.metadata, state)
+                else k (CastConcrete value (Types.ToDotNetType targetType) term.metadata, state)
+            | Constant(_, _, t)
+            | Expression(_, _, t) -> k (cast t targetType term, state)
             | StackRef _ ->
                 printfn "Warning: casting stack reference %O to %O!" term targetType
-                hierarchyCast state term targetType
+                hierarchyCast state term targetType k
             | HeapRef _
-            | Struct _ -> hierarchyCast state term targetType
+            | Struct _ -> hierarchyCast state term targetType k
             | _ -> __notImplemented__()
         in
         reduceExpression state ast.Argument (fun (term, state) ->
-        let newTerm, newState =
             match term.term with
-            | Union gvs -> Merging.guardedStateMap (fun state term -> primitiveCast state term targetType) gvs state
-            | _ -> primitiveCast state term targetType
-        in k (newTerm, newState))
+            | Union gvs -> Merging.guardedStateMapk (fun state term k -> primitiveCast state term targetType k) gvs state k
+            | _ -> primitiveCast state term targetType k)
 
     and checkCast mtd state targetType term =
         let derefForCast = Memory.derefWith (fun m s t -> Concrete null Null m, s)

--- a/VSharp.SILI/Memory.fs
+++ b/VSharp.SILI/Memory.fs
@@ -59,6 +59,7 @@ module internal Memory =
             let fields = Types.GetFieldsOf dotNetType false in
             let contents = Seq.map (fun (k, v) -> (Terms.MakeConcreteString k metadata, { value = defaultOf time metadata v; created = time; modified = time })) (Map.toSeq fields) |> Heap.ofSeq in
             Struct contents t metadata
+        | Pointer typ -> Terms.MakeNullPtr typ metadata
         | _ -> __notImplemented__()
 
     let internal mkDefault metadata typ =

--- a/VSharp.SILI/Memory.fs
+++ b/VSharp.SILI/Memory.fs
@@ -119,7 +119,7 @@ module internal Memory =
 
     let private canPoint mtd pointerAddr pointerType pointerTime locationAddr locationValue locationTime =
         // TODO: what if locationType is Null?
-        if locationTime > pointerTime then Terms.MakeFalse mtd
+        if locationTime > pointerTime then MakeFalse mtd
         else
             let addrEqual = Pointers.locationEqual mtd locationAddr pointerAddr in
             let typeSuits v =
@@ -132,7 +132,7 @@ module internal Memory =
                     gvs |> List.map (fun (g, v) -> (g, typeSuits v)) |> Merging.merge
                 | _ -> typeSuits locationValue
             in
-            addrEqual &&& typeEqual
+            if IsConcrete addrEqual then addrEqual else addrEqual &&& typeEqual
 
 // ------------------------------- Dereferencing/mutation -------------------------------
 

--- a/VSharp.SILI/Memory.fs
+++ b/VSharp.SILI/Memory.fs
@@ -301,6 +301,7 @@ module internal Memory =
     let rec private referenceTerm state name followHeapRefs term =
         match term.term with
         | Error _
+        | PointerTo _ -> StackRef name [] term.metadata
         | StackRef _
         | StaticRef _
         | HeapRef _ when followHeapRefs -> term

--- a/VSharp.SILI/Memory.fs
+++ b/VSharp.SILI/Memory.fs
@@ -279,7 +279,13 @@ module internal Memory =
                     k (result, withHeap state h'))
                 Merging.merge Merging.merge2Terms id id
         | Union gvs -> Merging.guardedStateMap (commonHierarchicalAccess actionNull update metadata) gvs state
-        | t -> internalfailf "expected reference, but got %O" t
+        | PointerTo viewType ->
+            let ref = GetReferenceFromPointer metadata term
+            let term, state = commonHierarchicalAccess actionNull update metadata state ref
+            if TypeOf term = viewType
+            then term, state
+            else __notImplemented__() // TODO: [columpio] [Reinterpretation]
+        | t -> internalfailf "expected reference or pointer, but got %O" t
 
     let internal hierarchicalAccess = commonHierarchicalAccess (fun m s _ ->
         let res, state = npe m s

--- a/VSharp.SILI/Terms.fs
+++ b/VSharp.SILI/Terms.fs
@@ -448,6 +448,9 @@ module public Terms =
     let public MakeNullRef typ metadata =
         HeapRef (((MakeZeroAddress metadata), typ), []) 0u metadata
 
+    let public MakeNullPtr typ metadata =
+        HeapPtr (((MakeZeroAddress metadata), typ), []) 0u typ metadata
+
     let public MakeNumber n metadata =
         Concrete n (Numeric(n.GetType())) metadata
 

--- a/VSharp.SILI/Terms.fs
+++ b/VSharp.SILI/Terms.fs
@@ -471,6 +471,10 @@ module public Terms =
         assert(Operations.isUnary operation)
         Expression (Operator(operation, isChecked)) [x] t metadata
 
+    let public MakeCast srcTyp dstTyp expr isChecked metadata =
+        if srcTyp = dstTyp then expr
+        else Expression (Cast(srcTyp, dstTyp, isChecked)) [expr] dstTyp metadata
+
     let public MakeStringKey typeName =
         MakeConcreteString typeName Metadata.empty
 

--- a/VSharp.Test/Tests/VSharp.CSharpUtils/Unix.gold
+++ b/VSharp.Test/Tests/VSharp.CSharpUtils/Unix.gold
@@ -4883,6 +4883,20 @@ System.String ==> STRUCT string[
 	| System.String.alignConst ~> 3
 	| System.String.charPtrAlignConst ~> 1]
 VSharp.CSharpUtils.Tests.Unsafe ==> STRUCT VSharp.CSharpUtils.Tests.Unsafe[]
+METHOD: System.Int32 VSharp.CSharpUtils.Tests.Unsafe.DoubleIndirection()
+RESULT: 428999
+HEAP:
+1 ==> STRUCT string[
+	| System.String.m_FirstChar ~> 
+	| System.String.m_StringLength ~> 0]
+System.String ==> STRUCT string[
+	| System.String.Empty ~> (HeapRef 1)
+	| System.String.TrimBoth ~> 2
+	| System.String.TrimHead ~> 0
+	| System.String.TrimTail ~> 1
+	| System.String.alignConst ~> 3
+	| System.String.charPtrAlignConst ~> 1]
+VSharp.CSharpUtils.Tests.Unsafe ==> STRUCT VSharp.CSharpUtils.Tests.Unsafe[]
 METHOD: System.Int32[] VSharp.CSharpUtils.Tests.Lists.RetOneDArray1(System.Boolean, System.Boolean)
 RESULT: (HeapRef 2)
 HEAP:

--- a/VSharp.Test/Tests/VSharp.CSharpUtils/Unix.gold
+++ b/VSharp.Test/Tests/VSharp.CSharpUtils/Unix.gold
@@ -4897,6 +4897,24 @@ System.String ==> STRUCT string[
 	| System.String.alignConst ~> 3
 	| System.String.charPtrAlignConst ~> 1]
 VSharp.CSharpUtils.Tests.Unsafe ==> STRUCT VSharp.CSharpUtils.Tests.Unsafe[]
+METHOD: System.Int32 VSharp.CSharpUtils.Tests.Unsafe.ReturnIntFromIntPtr(System.Int32)
+RESULT: myFavouriteParameter
+HEAP:
+1 ==> STRUCT string[
+	| System.String.m_FirstChar ~> 
+	| System.String.m_StringLength ~> 0]
+System.IntPtr ==> STRUCT System.IntPtr[
+	| System.IntPtr.Zero ~> STRUCT System.IntPtr[
+		| System.IntPtr.m_value ~> null]]
+System.String ==> STRUCT string[
+	| System.String.Empty ~> (HeapRef 1)
+	| System.String.TrimBoth ~> 2
+	| System.String.TrimHead ~> 0
+	| System.String.TrimTail ~> 1
+	| System.String.alignConst ~> 3
+	| System.String.charPtrAlignConst ~> 1]
+System.ValueType ==> STRUCT System.ValueType[]
+VSharp.CSharpUtils.Tests.Unsafe ==> STRUCT VSharp.CSharpUtils.Tests.Unsafe[]
 METHOD: System.Int32[] VSharp.CSharpUtils.Tests.Lists.RetOneDArray1(System.Boolean, System.Boolean)
 RESULT: (HeapRef 2)
 HEAP:

--- a/VSharp.Test/Tests/VSharp.CSharpUtils/Unix.gold
+++ b/VSharp.Test/Tests/VSharp.CSharpUtils/Unix.gold
@@ -4869,6 +4869,20 @@ System.String ==> STRUCT string[
 	| System.String.alignConst ~> 3
 	| System.String.charPtrAlignConst ~> 1]
 VSharp.CSharpUtils.Tests.Unsafe ==> STRUCT VSharp.CSharpUtils.Tests.Unsafe[]
+METHOD: System.Int32 VSharp.CSharpUtils.Tests.Unsafe.ReturnConst()
+RESULT: 421234123
+HEAP:
+1 ==> STRUCT string[
+	| System.String.m_FirstChar ~> 
+	| System.String.m_StringLength ~> 0]
+System.String ==> STRUCT string[
+	| System.String.Empty ~> (HeapRef 1)
+	| System.String.TrimBoth ~> 2
+	| System.String.TrimHead ~> 0
+	| System.String.TrimTail ~> 1
+	| System.String.alignConst ~> 3
+	| System.String.charPtrAlignConst ~> 1]
+VSharp.CSharpUtils.Tests.Unsafe ==> STRUCT VSharp.CSharpUtils.Tests.Unsafe[]
 METHOD: System.Int32[] VSharp.CSharpUtils.Tests.Lists.RetOneDArray1(System.Boolean, System.Boolean)
 RESULT: (HeapRef 2)
 HEAP:

--- a/VSharp.Test/Tests/VSharp.CSharpUtils/Unix.gold
+++ b/VSharp.Test/Tests/VSharp.CSharpUtils/Unix.gold
@@ -5675,9 +5675,7 @@ RESULT: UNION[
 HEAP:
 1 ==> STRUCT string[
 	| System.String.m_FirstChar ~> 
-	| System.String.m_StringLength ~> 0
-	| VSharp.CSharpUtils.Tests.Typecast.Piece.Rate ~> UNION[
-		| !(0 == obj) & (!System.Object1 | System.String) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) & 1 == obj ~> VSharp.CSharpUtils.Tests.Typecast.Piece.Rate]]
+	| System.String.m_StringLength ~> 0]
 10 ==> STRUCT System.NullReferenceException[
 	| System.Exception._HResult ~> UNION[
 		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) ~> -2147467261]
@@ -5723,9 +5721,7 @@ HEAP:
 		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) ~> null]
 	| System.Runtime.Serialization.SafeSerializationManager.m_serializedStates ~> UNION[
 		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) ~> null]]
-2 ==> STRUCT VSharp.CSharpUtils.Tests.Typecast.Piece[
-	| VSharp.CSharpUtils.Tests.Typecast.Piece.Rate ~> UNION[
-		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) & 2 == obj ~> VSharp.CSharpUtils.Tests.Typecast.Piece.Rate]]
+2 ==> STRUCT VSharp.CSharpUtils.Tests.Typecast.Piece[]
 3 ==> STRUCT System.InvalidCastException[
 	| System.Exception._HResult ~> -2147467262
 	| System.Exception._className ~> null
@@ -5798,7 +5794,7 @@ HEAP:
 		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) ~> null]]
 obj ==> STRUCT <Subtype of System.Object>[
 	| VSharp.CSharpUtils.Tests.Typecast.Piece.Rate ~> UNION[
-		| !(0 == obj) & (!(1 == obj) | !System.String & System.Object1) & (!(2 == obj) | !VSharp.CSharpUtils.Tests.Typecast.Piece & System.Object1) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) ~> VSharp.CSharpUtils.Tests.Typecast.Piece.Rate]]
+		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) ~> VSharp.CSharpUtils.Tests.Typecast.Piece.Rate]]
 System.Environment ==> STRUCT System.Environment[
 	| System.Environment.mono_corlib_version ~> UNION[
 		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) ~> 1050400003]

--- a/VSharp.Test/Tests/VSharp.CSharpUtils/Win32NT.gold
+++ b/VSharp.Test/Tests/VSharp.CSharpUtils/Win32NT.gold
@@ -5200,6 +5200,20 @@ System.String ==> STRUCT string[
 	| System.String.alignConst ~> 3
 	| System.String.charPtrAlignConst ~> 1]
 VSharp.CSharpUtils.Tests.Unsafe ==> STRUCT VSharp.CSharpUtils.Tests.Unsafe[]
+METHOD: System.Int32 VSharp.CSharpUtils.Tests.Unsafe.DoubleIndirection()
+RESULT: 428999
+HEAP:
+1 ==> STRUCT string[
+	| System.String.m_FirstChar ~> 
+	| System.String.m_StringLength ~> 0]
+System.String ==> STRUCT string[
+	| System.String.Empty ~> (HeapRef 1)
+	| System.String.TrimBoth ~> 2
+	| System.String.TrimHead ~> 0
+	| System.String.TrimTail ~> 1
+	| System.String.alignConst ~> 3
+	| System.String.charPtrAlignConst ~> 1]
+VSharp.CSharpUtils.Tests.Unsafe ==> STRUCT VSharp.CSharpUtils.Tests.Unsafe[]
 METHOD: System.Int32 VSharp.CSharpUtils.Tests.Lists.LowerBoundExceptionTest(System.Int32[,])
 RESULT: <ERROR: UNION[
 	| !(0 == array) ~> (HeapRef 8)

--- a/VSharp.Test/Tests/VSharp.CSharpUtils/Win32NT.gold
+++ b/VSharp.Test/Tests/VSharp.CSharpUtils/Win32NT.gold
@@ -6452,9 +6452,7 @@ RESULT: UNION[
 HEAP:
 1 ==> STRUCT string[
 	| System.String.m_FirstChar ~> 
-	| System.String.m_StringLength ~> 0
-	| VSharp.CSharpUtils.Tests.Typecast.Piece.Rate ~> UNION[
-		| !(0 == obj) & (!System.Object1 | System.String) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) & 1 == obj ~> VSharp.CSharpUtils.Tests.Typecast.Piece.Rate]]
+	| System.String.m_StringLength ~> 0]
 10 ==> STRUCT System.NullReferenceException[
 	| System.Exception._HResult ~> UNION[
 		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) ~> -2147467261]
@@ -6510,9 +6508,7 @@ HEAP:
 		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) ~> null]
 	| System.Runtime.Serialization.SafeSerializationManager.m_serializedStates ~> UNION[
 		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) ~> null]]
-2 ==> STRUCT VSharp.CSharpUtils.Tests.Typecast.Piece[
-	| VSharp.CSharpUtils.Tests.Typecast.Piece.Rate ~> UNION[
-		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) & 2 == obj ~> VSharp.CSharpUtils.Tests.Typecast.Piece.Rate]]
+2 ==> STRUCT VSharp.CSharpUtils.Tests.Typecast.Piece[]
 3 ==> STRUCT System.InvalidCastException[
 	| System.Exception._HResult ~> -2147467262
 	| System.Exception._className ~> null
@@ -6601,7 +6597,7 @@ HEAP:
 		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) ~> null]]
 obj ==> STRUCT <Subtype of System.Object>[
 	| VSharp.CSharpUtils.Tests.Typecast.Piece.Rate ~> UNION[
-		| !(0 == obj) & (!(1 == obj) | !System.String & System.Object1) & (!(2 == obj) | !VSharp.CSharpUtils.Tests.Typecast.Piece & System.Object1) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) ~> VSharp.CSharpUtils.Tests.Typecast.Piece.Rate]]
+		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) ~> VSharp.CSharpUtils.Tests.Typecast.Piece.Rate]]
 System.Environment ==> STRUCT System.Environment[
 	| System.Environment.MaxEnvVariableValueLength ~> UNION[
 		| !(0 == obj) & (!System.Object1 | VSharp.CSharpUtils.Tests.Typecast.Piece) ~> 32767]

--- a/VSharp.Test/Tests/VSharp.CSharpUtils/Win32NT.gold
+++ b/VSharp.Test/Tests/VSharp.CSharpUtils/Win32NT.gold
@@ -5214,6 +5214,25 @@ System.String ==> STRUCT string[
 	| System.String.alignConst ~> 3
 	| System.String.charPtrAlignConst ~> 1]
 VSharp.CSharpUtils.Tests.Unsafe ==> STRUCT VSharp.CSharpUtils.Tests.Unsafe[]
+METHOD: System.Int32 VSharp.CSharpUtils.Tests.Unsafe.ReturnIntFromIntPtr(System.Int32)
+RESULT: myFavouriteParameter
+HEAP:
+1 ==> STRUCT string[
+	| System.String.m_FirstChar ~> 
+	| System.String.m_StringLength ~> 0]
+System.IntPtr ==> STRUCT System.IntPtr[
+	| System.IntPtr.Zero ~> STRUCT System.IntPtr[
+		| System.IntPtr.m_value ~> null]]
+System.Object ==> STRUCT System.Object[]
+System.String ==> STRUCT string[
+	| System.String.Empty ~> (HeapRef 1)
+	| System.String.TrimBoth ~> 2
+	| System.String.TrimHead ~> 0
+	| System.String.TrimTail ~> 1
+	| System.String.alignConst ~> 3
+	| System.String.charPtrAlignConst ~> 1]
+System.ValueType ==> STRUCT System.ValueType[]
+VSharp.CSharpUtils.Tests.Unsafe ==> STRUCT VSharp.CSharpUtils.Tests.Unsafe[]
 METHOD: System.Int32 VSharp.CSharpUtils.Tests.Lists.LowerBoundExceptionTest(System.Int32[,])
 RESULT: <ERROR: UNION[
 	| !(0 == array) ~> (HeapRef 8)

--- a/VSharp.Test/Tests/VSharp.CSharpUtils/Win32NT.gold
+++ b/VSharp.Test/Tests/VSharp.CSharpUtils/Win32NT.gold
@@ -5186,6 +5186,20 @@ System.String ==> STRUCT string[
 	| System.String.alignConst ~> 3
 	| System.String.charPtrAlignConst ~> 1]
 VSharp.CSharpUtils.Tests.Unsafe ==> STRUCT VSharp.CSharpUtils.Tests.Unsafe[]
+METHOD: System.Int32 VSharp.CSharpUtils.Tests.Unsafe.ReturnConst()
+RESULT: 421234123
+HEAP:
+1 ==> STRUCT string[
+	| System.String.m_FirstChar ~> 
+	| System.String.m_StringLength ~> 0]
+System.String ==> STRUCT string[
+	| System.String.Empty ~> (HeapRef 1)
+	| System.String.TrimBoth ~> 2
+	| System.String.TrimHead ~> 0
+	| System.String.TrimTail ~> 1
+	| System.String.alignConst ~> 3
+	| System.String.charPtrAlignConst ~> 1]
+VSharp.CSharpUtils.Tests.Unsafe ==> STRUCT VSharp.CSharpUtils.Tests.Unsafe[]
 METHOD: System.Int32 VSharp.CSharpUtils.Tests.Lists.LowerBoundExceptionTest(System.Int32[,])
 RESULT: <ERROR: UNION[
 	| !(0 == array) ~> (HeapRef 8)


### PR DESCRIPTION
- TermNode.ToString() for Pointers and References
- Reduce of literal reference (to handle `*&42`)
- Reduce address of expression (to handle `****&&&&42`)
- Pointer indirection for simple cases (int x; int* p = &x; *p)
- Fix: _right_ casting of reference types
- Basic pointer casting
    - T* -> P* iff sizeof(T) = sizeof(P)
    - void* <-> T*